### PR TITLE
Fix (most) race conditions in updating manifest

### DIFF
--- a/scripts/jenkinsfiles/preint/Jenkinsfile
+++ b/scripts/jenkinsfiles/preint/Jenkinsfile
@@ -32,7 +32,7 @@ node('preint'){
 
   stage('Update manifest'){
     dir('cws-cares'){
-      sh 'git push origin master'
+      sh 'git pull --rebase origin master && git push origin master'
     }
   }
 


### PR DESCRIPTION
This instructs Jenkins to do a pull with rebase before attempting to update the manifest file. This should help it resolve most issues that otherwise result in the push being rejected as a non-fast-forward. Namely, if somebody updates some *other* manifest file, this will still succeed.

There is still a chance of a conflict within the prient.yml manifest file itself, in which case manual resolution is probably necessary anyways.

Testing this with the Preint pipeline first, although if it works we should also apply it to the Integration pipeline. (I'm also not 100% sure that Jenkins pulls these files directly from this repo... so please help me out by updating wherever it is necessary.)