### PR TITLE
Fit 353 update intake manifest in integration

### DIFF
--- a/scripts/jenkinsfiles/integration/Jenkinsfile
+++ b/scripts/jenkinsfiles/integration/Jenkinsfile
@@ -1,3 +1,5 @@
+@Library('jenkins-pipeline-utils') _
+
 node('integration'){
   properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '5')),
     [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
@@ -10,17 +12,8 @@ node('integration'){
 
   stage('Get necessary artifacts'){
     git branch: 'master', credentialsId: '433ac100-b3c2-4519-b4d6-207c029a103b', url: 'git@github.com:ca-cwds/devops.git'
-    dir('cws-cares'){
-      git branch: 'master', credentialsId: '433ac100-b3c2-4519-b4d6-207c029a103b', url: 'git@github.com:ca-cwds/cws-cares.git'
-    }
     dir('de-ansible'){
       git branch: 'master', credentialsId: '433ac100-b3c2-4519-b4d6-207c029a103b', url: 'git@github.com:ca-cwds/de-ansible.git'
-    }
-  }
-
-  stage('Check version formatting is correct'){
-    withEnv(["APP_NAME=intake", "ENVIRONMENT_NAME=integration", "VERSION=$APP_VERSION"]) {
-      sh './scripts/utils/manifest_tagging.rb'
     }
   }
 
@@ -30,10 +23,8 @@ node('integration'){
     }
   }
 
-  stage('Update manifest'){
-    dir('cws-cares'){
-      sh 'git push origin master'
-    }
+   stage('Update manifest'){
+    updateManifest("intake", "integration", "433ac100-b3c2-4519-b4d6-207c029a103b", env.APP_VERSION)
   }
 
   stage('Clean'){

--- a/scripts/jenkinsfiles/preint/Jenkinsfile
+++ b/scripts/jenkinsfiles/preint/Jenkinsfile
@@ -29,7 +29,7 @@ node('preint'){
 
   stage ('Trigger Smoke acceptance tests') {
            build job: '/Acceptance_tests/acceptance-test-intake/',
-               parameters: [string(name: 'APP_VERSION', value: "2.2.13")],
+               parameters: [string(name: 'INTAKE_APP_VERSION', value: "2.2.13")],
                wait: false
   }
 

--- a/scripts/jenkinsfiles/preint/Jenkinsfile
+++ b/scripts/jenkinsfiles/preint/Jenkinsfile
@@ -29,7 +29,7 @@ node('preint'){
 
   stage ('Trigger Smoke acceptance tests') {
            build job: '/Acceptance_tests/acceptance-test-intake/',
-               parameters: [string(name: 'INTAKE_APP_VERSION', value: "2.2.13")],
+               parameters: [string(name: 'INTAKE_APP_VERSION', value: env.APP_VERSION)],
                wait: false
   }
 

--- a/scripts/jenkinsfiles/preint/Jenkinsfile
+++ b/scripts/jenkinsfiles/preint/Jenkinsfile
@@ -32,7 +32,7 @@ node('preint'){
 
   stage ('Trigger Smoke acceptance tests') {
            build job: '/Acceptance_tests/acceptance-test-intake/',
-               parameters: [string(name: 'APP_VERSION', value: INTAKE_APP_VERSION)],
+               parameters: [string(name: 'APP_VERSION', value: $APP_VERSION)],
                wait: false
   }
 

--- a/scripts/jenkinsfiles/preint/Jenkinsfile
+++ b/scripts/jenkinsfiles/preint/Jenkinsfile
@@ -20,12 +20,6 @@ node('preint'){
     }
   }
 
-  stage('Check version formatting is correct'){
-    withEnv(["APP_NAME=intake", "ENVIRONMENT_NAME=preint", "VERSION=$APP_VERSION"]) {
-      sh './scripts/utils/manifest_tagging.rb'
-    }
-  }
-
   stage('Deploy to preint'){
     dir('de-ansible'){
       sh "ansible-playbook -e NEW_RELIC_AGENT=$ENABLE_NEWRELIC -e INTAKE_APP_VERSION=$APP_VERSION -i $INVENTORY $PLAYBOOK_NAME --vault-password-file ~/.ssh/vault.txt -vv"
@@ -38,7 +32,7 @@ node('preint'){
 
   stage ('Trigger Smoke acceptance tests') {
            build job: '/Acceptance_tests/acceptance-test-intake/',
-               parameters: [string(name: 'APP_VERSION', value: "${APP_VERSION}")],
+               parameters: [string(name: 'APP_VERSION', value: INTAKE_APP_VERSION)],
                wait: false
   }
 

--- a/scripts/jenkinsfiles/preint/Jenkinsfile
+++ b/scripts/jenkinsfiles/preint/Jenkinsfile
@@ -1,3 +1,5 @@
+@Library('jenkins-pipeline-utils') _
+
 node('preint'){
   properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '5')),
     [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
@@ -31,14 +33,12 @@ node('preint'){
   }
 
   stage('Update manifest'){
-    dir('cws-cares'){
-      sh 'git pull --rebase origin master && git push origin master'
-    }
+    updateManifest("intake", "preint", "433ac100-b3c2-4519-b4d6-207c029a103b", env.APP_VERSION)
   }
 
   stage ('Trigger Smoke acceptance tests') {
            build job: '/Acceptance_tests/acceptance-test-intake/',
-               parameters: [string(name: 'APP_VERSION', value: APP_VERSION)],
+               parameters: [string(name: 'APP_VERSION', value: "${APP_VERSION}")],
                wait: false
   }
 

--- a/scripts/jenkinsfiles/preint/Jenkinsfile
+++ b/scripts/jenkinsfiles/preint/Jenkinsfile
@@ -12,9 +12,6 @@ node('preint'){
 
   stage('Get necessary artifacts'){
     git branch: 'master', credentialsId: '433ac100-b3c2-4519-b4d6-207c029a103b', url: 'git@github.com:ca-cwds/devops.git'
-    dir('cws-cares'){
-      git branch: 'master', credentialsId: '433ac100-b3c2-4519-b4d6-207c029a103b', url: 'git@github.com:ca-cwds/cws-cares.git'
-    }
     dir('de-ansible'){
       git branch: 'master', credentialsId: '433ac100-b3c2-4519-b4d6-207c029a103b', url: 'git@github.com:ca-cwds/de-ansible.git'
     }
@@ -32,7 +29,7 @@ node('preint'){
 
   stage ('Trigger Smoke acceptance tests') {
            build job: '/Acceptance_tests/acceptance-test-intake/',
-               parameters: [string(name: 'APP_VERSION', value: env.APP_VERSION)],
+               parameters: [string(name: 'APP_VERSION', value: "2.2.13")],
                wait: false
   }
 

--- a/scripts/jenkinsfiles/preint/Jenkinsfile
+++ b/scripts/jenkinsfiles/preint/Jenkinsfile
@@ -32,7 +32,7 @@ node('preint'){
 
   stage ('Trigger Smoke acceptance tests') {
            build job: '/Acceptance_tests/acceptance-test-intake/',
-               parameters: [string(name: 'APP_VERSION', value: $APP_VERSION)],
+               parameters: [string(name: 'APP_VERSION', value: env.APP_VERSION)],
                wait: false
   }
 


### PR DESCRIPTION
## Jira: https://osi-cwds.atlassian.net/browse/FIT-353

## Description: As part of the FIT team, refactored the intake pre-int and integration Jenkins to use the [jenkins-pipeline-utils](https://github.com/ca-cwds/jenkins-pipeline-utils) to update the manifest instead of latest and removed the unnecessary script check.